### PR TITLE
New Annotation Tools in Talk to Figma MCP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,13 @@ The MCP server provides the following tools for interacting with Figma:
 - `get_node_info` - Get detailed information about a specific node
 - `get_nodes_info` - Get detailed information about multiple nodes by providing an array of node IDs
 
+### Annotations
+
+- `get_annotations` - Get all annotations in the current document or specific node
+- `set_annotation` - Create or update an annotation with markdown support
+- `set_multiple_annotations` - Batch create/update multiple annotations efficiently
+- `scan_nodes_by_types` - Scan for nodes with specific types (useful for finding annotation targets)
+
 ### Creating Elements
 
 - `create_rectangle` - Create a new rectangle with position, size, and optional name
@@ -137,6 +144,7 @@ The MCP server provides the following tools for interacting with Figma:
 - `move_node` - Move a node to a new position
 - `resize_node` - Resize a node with new dimensions
 - `delete_node` - Delete a node
+- `delete_multiple_nodes` - Delete multiple nodes at once efficiently
 - `clone_node` - Create a copy of an existing node with optional position offset
 
 ### Components & Styles
@@ -189,6 +197,15 @@ When working with the Figma MCP:
    - Use batch operations when possible
    - Consider structural relationships
    - Verify changes with targeted exports
+10. For converting legacy annotations:
+    - Scan text nodes to identify numbered markers and descriptions
+    - Use `scan_nodes_by_types` to find UI elements that annotations refer to
+    - Match markers with their target elements using path, name, or proximity
+    - Categorize annotations appropriately with `get_annotations` 
+    - Create native annotations with `set_multiple_annotations` in batches
+    - Verify all annotations are properly linked to their targets
+    - Delete legacy annotation nodes after successful conversion
+
 
 ## License
 

--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -146,10 +146,6 @@ async function handleCommand(command, params) {
       return await getAnnotations(params);
     case "set_annotation":
       return await setAnnotation(params);
-    case "ensure_annotation_category":
-      return await ensureAnnotationCategory(params);
-    case "get_annotation_categories":
-      return await getAnnotationCategories();
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -1879,22 +1875,6 @@ function generateCommandId() {
   return 'cmd_' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 }
 
-// Annotation command implementations
-
-async function getAnnotationCategories() {
-  try {
-    const categories = await figma.annotations.getAnnotationCategoriesAsync();
-    return categories.map(category => ({
-      id: category.id,
-      label: category.label,
-      color: category.color,
-      isPreset: category.isPreset
-    }));
-  } catch (error) {
-    console.error('Error in getAnnotationCategories:', error);
-    throw error;
-  }
-}
 
 async function getAnnotations(params) {
   try {
@@ -1970,42 +1950,6 @@ async function getAnnotations(params) {
     }
   } catch (error) {
     console.error('Error in getAnnotations:', error);
-    throw error;
-  }
-}
-
-async function ensureAnnotationCategory(params) {
-  try {
-    const { label, color } = params;
-    
-    // Get existing categories
-    const categories = await figma.annotations.getAnnotationCategoriesAsync();
-    
-    // Check if category already exists
-    const existingCategory = categories.find(c => c.label === label);
-    if (existingCategory) {
-      return {
-        id: existingCategory.id,
-        label: existingCategory.label,
-        color: existingCategory.color,
-        isPreset: existingCategory.isPreset
-      };
-    }
-    
-    // Create new category
-    const newCategory = await figma.annotations.addAnnotationCategoryAsync({
-      label,
-      color
-    });
-    
-    return {
-      id: newCategory.id,
-      label: newCategory.label,
-      color: newCategory.color,
-      isPreset: newCategory.isPreset
-    };
-  } catch (error) {
-    console.error('Error in ensureAnnotationCategory:', error);
     throw error;
   }
 }

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -783,6 +783,113 @@ server.tool(
   }
 );
 
+// Get Annotation Categories Tool
+server.tool(
+  "get_annotation_categories",
+  "Get all available annotation categories",
+  {},
+  async () => {
+    try {
+      const result = await sendCommandToFigma("get_annotation_categories");
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting annotation categories: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
+// Get Annotations Tool
+server.tool(
+  "get_annotations",
+  "Get all annotations in the current document or specific node",
+  {
+    nodeId: z.string().optional().describe("Optional node ID to get annotations for specific node"),
+    includeCategories: z.boolean().optional().default(true).describe("Whether to include category information")
+  },
+  async ({ nodeId, includeCategories }) => {
+    try {
+      const result = await sendCommandToFigma("get_annotations", { 
+        nodeId,
+        includeCategories
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting annotations: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
+// Set Annotation Tool
+server.tool(
+  "set_annotation",
+  "Create or update an annotation",
+  {
+    nodeId: z.string().describe("The ID of the node to annotate"),
+    annotationId: z.string().optional().describe("The ID of the annotation to update (if updating existing annotation)"),
+    labelMarkdown: z.string().describe("The annotation text in markdown format"),
+    categoryId: z.string().optional().describe("The ID of the annotation category"),
+    properties: z.array(z.object({
+      type: z.string()
+    })).optional().describe("Additional properties for the annotation")
+  },
+  async ({ nodeId, annotationId, labelMarkdown, categoryId, properties }) => {
+    try {
+      const result = await sendCommandToFigma("set_annotation", {
+        nodeId,
+        annotationId,
+        labelMarkdown,
+        categoryId,
+        properties
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error setting annotation: ${error instanceof Error ? error.message : String(error)}`
+          }
+        ]
+      };
+    }
+  }
+);
+
 // Get Team Components Tool
 // server.tool(
 //   "get_team_components",
@@ -1443,7 +1550,11 @@ type FigmaCommand =
   | "clone_node"
   | "set_text_content"
   | "scan_text_nodes"
-  | "set_multiple_text_contents";
+  | "set_multiple_text_contents"
+  | "get_annotations"
+  | "set_annotation"
+  | "ensure_annotation_category"
+  | "get_annotation_categories";
 
 // Helper function to process Figma node responses
 function processFigmaNodeResponse(result: unknown): any {
@@ -1722,8 +1833,6 @@ server.tool(
     }
   }
 );
-
-
 
 // Start the server
 async function main() {

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -723,6 +723,39 @@ server.tool(
   }
 );
 
+// Delete Multiple Nodes Tool
+server.tool(
+  "delete_multiple_nodes",
+  "Delete multiple nodes from Figma at once",
+  {
+    nodeIds: z.array(z.string()).describe("Array of node IDs to delete"),
+  },
+  async ({ nodeIds }) => {
+    try {
+      const result = await sendCommandToFigma("delete_multiple_nodes", { nodeIds });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error deleting multiple nodes: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
 // Export Node as Image Tool
 server.tool(
   "export_node_as_image",
@@ -1858,38 +1891,6 @@ This strategy focuses on practical implementation based on real-world usage patt
   }
 );
 
-// Delete Multiple Nodes Tool
-server.tool(
-  "delete_multiple_nodes",
-  "Delete multiple nodes from Figma at once",
-  {
-    nodeIds: z.array(z.string()).describe("Array of node IDs to delete"),
-  },
-  async ({ nodeIds }) => {
-    try {
-      const result = await sendCommandToFigma("delete_multiple_nodes", { nodeIds });
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(result)
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error deleting multiple nodes: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          },
-        ],
-      };
-    }
-  }
-);
 
 // Define command types and parameters
 type FigmaCommand =


### PR DESCRIPTION
## Description

Add new tools and prompts to Talk to Figma MCP for converting legacy annotations to Figma's native annotation system. This contribution enables users to:

- Convert legacy annotation frames to Figma's native annotations through conversation
- Automatically detect and match annotation markers with their target elements
- Clean up legacy annotation markers after conversion
- Process annotations in batches for better performance

## Changes

- Add `set_annotation` and `set_multiple_annotations` tools for native Figma annotations
- Add `scan_nodes_by_types` tool for finding annotation targets
- Add `delete_multiple_nodes` tool for cleaning up legacy markers
- Add annotation conversion strategy prompt
- Update README with new annotation-related features

## Demo

Check out the demo video here:
https://x.com/i/status/1908940072067731503

## Testing

1. Select a frame containing legacy annotations (numbered markers with description frames)
2. Use the annotation conversion strategy
3. Verify that:
   - Legacy annotations are correctly converted to native Figma annotations
   - Annotations are properly linked to their target elements
   - Legacy markers can be cleaned up after conversion
