### PR TITLE
Auto Layout Support in Talk to Figma MCP

### DIFF
--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -166,6 +166,8 @@ async function handleCommand(command, params) {
       return await scanNodesByTypes(params);
     case "set_multiple_annotations":
       return await setMultipleAnnotations(params);
+    case "set_layout_mode":
+      return await setLayoutMode(params);
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -449,6 +451,8 @@ async function createFrame(params) {
     fillColor,
     strokeColor,
     strokeWeight,
+    layoutMode = "NONE",
+    layoutWrap = "NO_WRAP"
   } = params || {};
 
   const frame = figma.createFrame();
@@ -456,6 +460,12 @@ async function createFrame(params) {
   frame.y = y;
   frame.resize(width, height);
   frame.name = name;
+
+  // Set layout mode if provided
+  if (layoutMode !== "NONE") {
+    frame.layoutMode = layoutMode;
+    frame.layoutWrap = layoutWrap;
+  }
 
   // Set fill color if provided
   if (fillColor) {
@@ -514,6 +524,8 @@ async function createFrame(params) {
     fills: frame.fills,
     strokes: frame.strokes,
     strokeWeight: frame.strokeWeight,
+    layoutMode: frame.layoutMode,
+    layoutWrap: frame.layoutWrap,
     parentId: frame.parent ? frame.parent.id : undefined,
   };
 }
@@ -2641,5 +2653,30 @@ async function deleteMultipleNodes(params) {
     results: results,
     completedInChunks: chunks.length,
     commandId,
+  };
+}
+
+async function setLayoutMode(params) {
+  const { nodeId, layoutMode, layoutWrap = "NO_WRAP" } = params;
+
+  // Get the node
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) {
+    throw new Error(`Node not found with ID: ${nodeId}`);
+  }
+
+  // Check if the node is a frame
+  if (node.type !== "FRAME") {
+    throw new Error(`Node with ID ${nodeId} is not a frame`);
+  }
+
+  // Set layout mode and wrap
+  node.layoutMode = layoutMode;
+  node.layoutWrap = layoutWrap;
+
+  return {
+    name: node.name,
+    layoutMode: node.layoutMode,
+    layoutWrap: node.layoutWrap
   };
 }


### PR DESCRIPTION
## Description

Add support for Figma auto layout to enhance Frame component functionality.
This feature allows users to:

* Set auto layout (horizontal/vertical) when creating Frames
* Adjust layout mode for existing Frames
* Control auto layout wrap behavior (wrap/no-wrap)

## Changes

* Add layoutMode and layoutWrap parameters to create_frame tool
* Implement new set_layout_mode tool for adjusting existing Frame layouts
* Add corresponding functionality in the Figma plugin

## Testing Steps

1. Create a new Frame using create_frame with layoutMode set to "HORIZONTAL" or "VERTICAL"
2. Verify that the Frame has the correct auto layout properties
3. Use set_layout_mode to change layout mode of an existing Frame
4. Verify that layout changes are applied successfully