### PR TITLE
docs: clarify setup instructions in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,9 +18,11 @@ https://github.com/user-attachments/assets/129a14d2-ed73-470f-9a4c-2240b2a4885c
 curl -fsSL https://bun.sh/install | bash
 ```
 
-2. Run setup, this will also install MCP in your Cursor's active project
+2. Clone this repository and run the setup command to install MCP into your project.
 
 ```bash
+# assuming you've already cloned the repository
+cd cursor-talk-to-figma-mcp
 bun setup
 ```
 


### PR DESCRIPTION
This PR updates the setup instructions in the README for better clarity.

Recently, my friend and I both encountered confusion during the second step (bun setup). It wasn’t clear that the command should be run inside the cloned project directory, which caused errors.

Changes made:
- Added a comment to clarify that bun setup should be run inside the cloned project folder.

Hopefully this small clarification helps other users avoid the same issue. Let me know if anything should be revised — happy to adjust!