### PR TITLE
feat: add set_image_fill and set_font commands

### DIFF
--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -155,6 +155,8 @@ async function handleCommand(command, params) {
       return await setCornerRadius(params);
     case "set_text_content":
       return await setTextContent(params);
+    case "set_font":
+      return await setFont(params);
     case "clone_node":
       return await cloneNode(params);
     case "scan_text_nodes":
@@ -1465,6 +1467,44 @@ async function setTextContent(params) {
     };
   } catch (error) {
     throw new Error(`Error setting text content: ${error.message}`);
+  }
+}
+
+async function setFont(params) {
+  const { nodeId, fontFamily, fontStyle } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  if (!fontFamily) {
+    throw new Error("Missing fontFamily parameter");
+  }
+
+  const style = fontStyle || "Regular";
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) {
+    throw new Error(`Node not found with ID: ${nodeId}`);
+  }
+
+  if (node.type !== "TEXT") {
+    throw new Error(`Node is not a text node: ${nodeId}`);
+  }
+
+  try {
+    const newFont = { family: fontFamily, style: style };
+    await figma.loadFontAsync(newFont);
+    node.fontName = newFont;
+
+    return {
+      id: node.id,
+      name: node.name,
+      fontName: node.fontName,
+      characters: node.characters,
+    };
+  } catch (error) {
+    throw new Error(`Error setting font: ${error.message}`);
   }
 }
 


### PR DESCRIPTION
## Summary

This PR adds two new commands to the Figma plugin:

### 1. `set_image_fill` command
- Set image fills on nodes using base64 encoded images or URLs
- Supports `scaleMode` parameter (FILL, FIT, CROP, TILE)
- Custom base64 decoder implementation (no `atob` dependency for plugin compatibility)

### 2. `set_font` command  
- Change font family and style of text nodes programmatically
- Accepts `fontFamily` and optional `fontStyle` parameters
- Loads font asynchronously before applying

## Use Cases

These commands enable automation workflows like:
- **App Store screenshot automation**: Insert app screenshots into Figma mockups
- **Batch text styling**: Change fonts across multiple text nodes programmatically
- **Design system updates**: Update font families across templates

## Test Plan

- [x] Tested `set_image_fill` with base64 encoded PNG images
- [x] Tested `set_font` with Inter, SF Pro fonts
- [x] Verified commands work via WebSocket connection
