### PR TITLE
fix: expose node effects (drop shadow, inner shadow, blur) in filterFigmaNode

### DIFF
--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -355,6 +355,17 @@ function filterFigmaNode(node) {
     });
   }
 
+  if (node.effects && node.effects.length > 0) {
+    filtered.effects = node.effects.map((effect) => {
+      var processedEffect = Object.assign({}, effect);
+      delete processedEffect.boundVariables;
+      if (processedEffect.color) {
+        processedEffect.color = rgbaToHex(processedEffect.color);
+      }
+      return processedEffect;
+    });
+  }
+
   if (node.cornerRadius !== undefined) {
     filtered.cornerRadius = node.cornerRadius;
   }

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -277,6 +277,17 @@ function filterFigmaNode(node: any) {
     });
   }
 
+  if (node.effects && node.effects.length > 0) {
+    filtered.effects = node.effects.map((effect: any) => {
+      const processedEffect = { ...effect };
+      delete processedEffect.boundVariables;
+      if (processedEffect.color) {
+        processedEffect.color = rgbaToHex(processedEffect.color);
+      }
+      return processedEffect;
+    });
+  }
+
   if (node.cornerRadius !== undefined) {
     filtered.cornerRadius = node.cornerRadius;
   }


### PR DESCRIPTION
## Summary

- Adds `effects` array serialization to `filterFigmaNode` in both the Figma plugin (`code.js`) and MCP server (`server.ts`)
- Strips `boundVariables` from each effect and converts RGBA colors to hex via `rgbaToHex`

Closes #112