### PR TITLE
feat: add fontFamily, letterSpacing and lineHeight to text tools

### DIFF
--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -551,6 +551,18 @@ server.tool(
       })
       .optional()
       .describe("Font color in RGBA format"),
+    fontFamily: z
+      .string()
+      .optional()
+      .describe("Font family name (e.g., 'Inter', 'Roboto'). Must be installed locally or available in Figma. Defaults to 'Inter'."),
+    letterSpacing: z
+      .number()
+      .optional()
+      .describe("Letter spacing in pixels (e.g., -1.08 for tight, 1.2 for loose). Defaults to 0."),
+    lineHeight: z
+      .number()
+      .optional()
+      .describe("Line height in pixels (e.g., 28). If not provided, uses 'AUTO' line height."),
     name: z
       .string()
       .optional()
@@ -560,7 +572,7 @@ server.tool(
       .optional()
       .describe("Optional parent node ID to append the text to"),
   },
-  async ({ x, y, text, fontSize, fontWeight, fontColor, name, parentId }: any) => {
+  async ({ x, y, text, fontSize, fontWeight, fontColor, fontFamily, letterSpacing, lineHeight, name, parentId }: any) => {
     try {
       const result = await sendCommandToFigma("create_text", {
         x,
@@ -569,6 +581,9 @@ server.tool(
         fontSize: fontSize || 14,
         fontWeight: fontWeight || 400,
         fontColor: fontColor || { r: 0, g: 0, b: 0, a: 1 },
+        fontFamily: fontFamily || "Inter",
+        letterSpacing,
+        lineHeight,
         name: name || "Text",
         parentId,
       });
@@ -902,12 +917,32 @@ server.tool(
   {
     nodeId: z.string().describe("The ID of the text node to modify"),
     text: z.string().describe("New text content"),
+    fontFamily: z
+      .string()
+      .optional()
+      .describe("Optional font family to change to (e.g., 'Inter', 'Roboto'). If not provided, keeps existing font."),
+    fontWeight: z
+      .number()
+      .optional()
+      .describe("Optional font weight to change to (e.g., 400, 700). If not provided, keeps existing weight."),
+    letterSpacing: z
+      .number()
+      .optional()
+      .describe("Optional letter spacing in pixels (e.g., -1.08 for tight, 1.2 for loose). If not provided, keeps existing value."),
+    lineHeight: z
+      .number()
+      .optional()
+      .describe("Optional line height in pixels (e.g., 28). If not provided, keeps existing value."),
   },
-  async ({ nodeId, text }: any) => {
+  async ({ nodeId, text, fontFamily, fontWeight, letterSpacing, lineHeight }: any) => {
     try {
       const result = await sendCommandToFigma("set_text_content", {
         nodeId,
         text,
+        fontFamily,
+        fontWeight,
+        letterSpacing,
+        lineHeight,
       });
       const typedResult = result as { name: string };
       return {
@@ -2680,6 +2715,9 @@ type CommandParams = {
     text: string;
     fontSize?: number;
     fontWeight?: number;
+    fontFamily?: string;
+    letterSpacing?: number;
+    lineHeight?: number;
     fontColor?: { r: number; g: number; b: number; a?: number };
     name?: string;
     parentId?: string;
@@ -2754,6 +2792,10 @@ type CommandParams = {
   set_text_content: {
     nodeId: string;
     text: string;
+    fontFamily?: string;
+    fontWeight?: number;
+    letterSpacing?: number;
+    lineHeight?: number;
   };
   scan_text_nodes: {
     nodeId: string;


### PR DESCRIPTION
## Summary

Adds a `fontFamily` parameter to the `create_text` and `set_text_content` tools, allowing users to specify custom font families when creating or modifying text nodes in Figma.

### Changes

- **`create_text` (server.ts + code.js):** Added optional `fontFamily` parameter (defaults to `"Inter"`). The Figma plugin attempts to load the requested font family and falls back to Inter if it's not available.
- **`set_text_content` (server.ts + code.js):** Added optional `fontFamily` and `fontWeight` parameters for changing the font of existing text nodes. If not provided, the existing font is preserved.
- **TypeScript types:** Updated the `FigmaCommand` type to include the new optional fields.

### Motivation

Currently, all text created via `create_text` uses hardcoded `"Inter"` font family. This prevents users from building design systems that use custom fonts (e.g., brand typography like "Arbeit Pro", "Roboto", etc.).

Addresses #138.

### API

```typescript
// create_text - new optional parameter
fontFamily?: string  // e.g., "Roboto", "Arbeit Pro Trial" (default: "Inter")

// set_text_content - new optional parameters
fontFamily?: string  // change font family of existing text
fontWeight?: number  // change font weight of existing text
```

### Fallback behavior

If the requested font is not available in Figma (not installed locally or not in the document), the plugin:
1. Logs a warning to the console
2. Falls back to `"Inter"` (for `create_text`) or keeps the existing font (for `set_text_content`)

This ensures backward compatibility — existing usage without `fontFamily` continues to work exactly as before.

## Test plan

- [ ] Create text with default font (no `fontFamily`) — should use Inter as before
- [ ] Create text with `fontFamily: "Roboto"` — should use Roboto if available
- [ ] Create text with unavailable font — should fall back to Inter with console warning
- [ ] Use `set_text_content` with `fontFamily` to change an existing node's font
- [ ] Use `set_text_content` without `fontFamily` — should preserve existing font


Made with [Cursor](https://cursor.com)