### PR TITLE
Support local components and progress forwarding improvements

### DIFF
--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -8,7 +8,7 @@ const state = {
 
 
 // Helper function for progress updates
-function sendProgressUpdate(
+async function sendProgressUpdate(
   commandId,
   commandType,
   status,
@@ -46,6 +46,10 @@ function sendProgressUpdate(
   // Send to UI
   figma.ui.postMessage(update);
   console.log(`Progress update: ${status} - ${progress}% - ${message}`);
+
+  // Yield so the Figma plugin sandbox flushes postMessage to ui.html
+  // before the next iteration begins
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
   return update;
 }
@@ -142,7 +146,7 @@ async function handleCommand(command, params) {
     case "get_styles":
       return await getStyles();
     case "get_local_components":
-      return await getLocalComponents();
+      return await getLocalComponents(params);
     // case "get_team_components":
     //   return await getTeamComponents();
     case "create_component_instance":
@@ -1127,20 +1131,66 @@ async function getStyles() {
   };
 }
 
-async function getLocalComponents() {
-  await figma.loadAllPagesAsync();
+async function getLocalComponents(params) {
+  const commandId = (params && params.commandId) || generateCommandId();
+  const pages = figma.root.children;
+  const totalPages = pages.length;
 
-  const components = figma.root.findAllWithCriteria({
-    types: ["COMPONENT"],
-  });
+  await sendProgressUpdate(
+    commandId,
+    "get_local_components",
+    "started",
+    0,
+    totalPages,
+    0,
+    "Starting component scan across " + totalPages + " pages...",
+    null
+  );
+
+  var allComponents = [];
+
+  for (var i = 0; i < totalPages; i++) {
+    var page = pages[i];
+    await page.loadAsync();
+
+    var pageComponents = page.findAllWithCriteria({ types: ["COMPONENT"] });
+
+    for (var j = 0; j < pageComponents.length; j++) {
+      var component = pageComponents[j];
+      allComponents.push({
+        id: component.id,
+        name: component.name,
+        key: "key" in component ? component.key : null,
+      });
+    }
+
+    var progress = Math.round(((i + 1) / totalPages) * 100);
+    await sendProgressUpdate(
+      commandId,
+      "get_local_components",
+      "in_progress",
+      progress,
+      totalPages,
+      i + 1,
+      "Scanned " + page.name + ": " + pageComponents.length + " components (total so far: " + allComponents.length + ")",
+      null
+    );
+  }
+
+  await sendProgressUpdate(
+    commandId,
+    "get_local_components",
+    "completed",
+    100,
+    totalPages,
+    totalPages,
+    "Found " + allComponents.length + " components across " + totalPages + " pages",
+    null
+  );
 
   return {
-    count: components.length,
-    components: components.map((component) => ({
-      id: component.id,
-      name: component.name,
-      key: "key" in component ? component.key : null,
-    })),
+    count: allComponents.length,
+    components: allComponents,
   };
 }
 
@@ -1212,7 +1262,7 @@ async function createComponentInstance(params) {
       y: instance.y,
       width: instance.width,
       height: instance.height,
-      mainComponentId: mainComponent?.id,
+      mainComponentId: mainComponent ? mainComponent.id : undefined,
     };
   } catch (error) {
     throw new Error(`Error creating component instance: ${error.message}`);

--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -1164,20 +1164,46 @@ async function getLocalComponents() {
 // }
 
 async function createComponentInstance(params) {
-  const { componentKey, x = 0, y = 0 } = params || {};
+  const { componentKey, componentId, x = 0, y = 0, parentId } = params || {};
 
-  if (!componentKey) {
-    throw new Error("Missing componentKey parameter");
+  if (!componentKey && !componentId) {
+    throw new Error("Missing componentKey or componentId parameter. Use componentId for local components (from get_local_components), or componentKey for published library components.");
   }
 
   try {
-    const component = await figma.importComponentByKeyAsync(componentKey);
-    const instance = component.createInstance();
+    let component;
 
+    if (componentId) {
+      // Local component: get node directly by ID
+      const node = await figma.getNodeByIdAsync(componentId);
+      if (!node) {
+        throw new Error(`Component node not found with id: ${componentId}`);
+      }
+      if (node.type !== "COMPONENT") {
+        throw new Error(`Node ${componentId} is not a COMPONENT (got type: ${node.type}). Use get_local_components to find valid component IDs.`);
+      }
+      component = node;
+    } else {
+      // Published library component: import by key
+      component = await figma.importComponentByKeyAsync(componentKey);
+    }
+
+    const instance = component.createInstance();
     instance.x = x;
     instance.y = y;
 
-    figma.currentPage.appendChild(instance);
+    if (parentId) {
+      const parent = await figma.getNodeByIdAsync(parentId);
+      if (parent && "appendChild" in parent) {
+        parent.appendChild(instance);
+      } else {
+        figma.currentPage.appendChild(instance);
+      }
+    } else {
+      figma.currentPage.appendChild(instance);
+    }
+
+    const mainComponent = await instance.getMainComponentAsync();
 
     return {
       id: instance.id,
@@ -1186,7 +1212,7 @@ async function createComponentInstance(params) {
       y: instance.y,
       width: instance.width,
       height: instance.height,
-      componentId: instance.componentId,
+      mainComponentId: mainComponent?.id,
     };
   } catch (error) {
     throw new Error(`Error creating component instance: ${error.message}`);

--- a/src/cursor_mcp_plugin/ui.html
+++ b/src/cursor_mcp_plugin/ui.html
@@ -556,6 +556,8 @@
         // If it's a new command
         if (data.command) {
           try {
+            state.activeRequestId = data.id;
+
             // Send the command to the plugin code
             parent.postMessage(
               {
@@ -742,13 +744,14 @@
 
         console.log("Sending progress update to server:", progressData);
 
+        const requestId = state.activeRequestId || progressData.commandId;
         state.socket.send(
           JSON.stringify({
-            id: progressData.commandId,
+            id: requestId,
             type: "progress_update",
             channel: state.channel,
             message: {
-              id: progressData.commandId,
+              id: requestId,
               type: "progress_update",
               data: progressData,
             },

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -180,6 +180,21 @@ const server = Bun.serve({
             console.log(`✓ Broadcast to ${broadcastCount} peer(s) in channel "${channelName}"`);
           }
         }
+
+        // Forward progress_update messages to the MCP server so it can reset
+        if (data.type === "progress_update") {
+          const channelName = data.channel;
+          if (!channelName) return;
+
+          const channelClients = channels.get(channelName);
+          if (!channelClients || !channelClients.has(ws)) return;
+
+          channelClients.forEach((client) => {
+            if (client !== ws && client.readyState === WebSocket.OPEN) {
+              client.send(JSON.stringify(data));
+            }
+          });
+        }
       } catch (err) {
         console.error("Error handling message:", err);
       }

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -1197,18 +1197,22 @@ server.tool(
 // Create Component Instance Tool
 server.tool(
   "create_component_instance",
-  "Create an instance of a component in Figma",
+  "Create an instance of a component in Figma. For LOCAL components (from get_local_components), use componentId with the id field. For published LIBRARY components, use componentKey with the publishedKey field.",
   {
-    componentKey: z.string().describe("Key of the component to instantiate"),
+    componentId: z.string().optional().describe("ID of a local component (use the id field from get_local_components result). Use this for unpublished/local components."),
+    componentKey: z.string().optional().describe("Key of a published library component to instantiate (use the publishedKey field from get_local_components result). Only works for published components."),
     x: z.number().describe("X position"),
     y: z.number().describe("Y position"),
+    parentId: z.string().optional().describe("Optional parent node ID to place the instance into"),
   },
-  async ({ componentKey, x, y }: any) => {
+  async ({ componentId, componentKey, x, y, parentId }: any) => {
     try {
       const result = await sendCommandToFigma("create_component_instance", {
+        componentId,
         componentKey,
         x,
         y,
+        parentId,
       });
       const typedResult = result as any;
       return {


### PR DESCRIPTION
## Linked Issues
Fixes #149
Fixes #150

## Why these issues happened
### #150 create_component_instance fails for local components
- The previous implementation attempted to resolve `componentId` only via `figma.importComponentByKeyAsync`.
- `importComponentByKeyAsync` works for published library components (component keys), not local in-file component node IDs.
- Result: when users passed a local component ID, lookup failed and instance creation could not proceed.

### #149 long-running commands time out after 30s
- MCP server keeps requests alive only when it receives progress signals from the plugin.
- The plugin emitted `progress_update`, but the relay path did not consistently forward this event to the MCP server.
- Without periodic progress updates, inactivity timers were not refreshed, so valid long-running tasks hit timeout.

## How this PR resolves them
### For #150
- Added local component support in `create_component_instance` by resolving in-file components from the current document context when `componentId` is local.
- Preserved existing behavior for published library components so both local and library component flows are supported.

### For #149
- Updated socket relay handling so `progress_update` messages are forwarded correctly end-to-end.
- Added yielding behavior after plugin `postMessage` paths and improved progress reporting flow to reduce event starvation during heavy operations.
- Result: progress signals reach MCP server in time and request inactivity timeout is properly reset.

## Scope
- This branch is based on `upstream/main` and contains only the two relevant commits.
- Included commits:
  - `b91ee59`
  - `7418060`
