### PR TITLE
fix(security): bump @modelcontextprotocol/sdk to ^1.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.13.1",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "uuid": "latest",
     "ws": "latest",
     "zod": "3.22.4"


### PR DESCRIPTION
Fixes #148

## Security Update

Bump `@modelcontextprotocol/sdk` from `1.13.1` to `^1.26.0`

This fixes **3 High-severity vulnerabilities**:

1. **CVE-2025-27104**: Cross-client data leaks
2. **Missing DNS rebinding protection**
3. **Other security patches** in SDK >=1.26.0

## Impact

Since this tool handles sensitive Figma design data over local WebSocket, these vulnerabilities are critical for enterprise adoption.

## Changelog

https://github.com/modelcontextprotocol/typescript-sdk/releases

## Testing

- Run `bun audit` or `npm audit` - should show 0 high vulnerabilities
- Verify MCP server still connects properly
- Test basic Figma operations