### PR TITLE
fix(plugin): add effects data to filterFigmaNode for get_node_info

### DIFF
--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -359,6 +359,18 @@ function filterFigmaNode(node) {
     });
   }
 
+  // Include effects (drop shadows, layer blur, etc.) from Figma API
+  if (node.effects && node.effects.length > 0) {
+    filtered.effects = node.effects.map((effect) => {
+      var processedEffect = Object.assign({}, effect);
+      // Convert color to hex if present
+      if (processedEffect.color) {
+        processedEffect.color = rgbaToHex(processedEffect.color);
+      }
+      return processedEffect;
+    });
+  }
+
   if (node.cornerRadius !== undefined) {
     filtered.cornerRadius = node.cornerRadius;
   }


### PR DESCRIPTION
Fixes #112

## Problem
Nodes with drop shadows and other effects were not exposing the `effects` array in `get_node_info` responses.

## Root Cause
`filterFigmaNode()` only processed `fills` and `strokes`, ignoring the `effects` field from Figma's `JSON_REST_V1` export.

## Fix
Added effects processing to `filterFigmaNode`:

```javascript
if (node.effects && node.effects.length > 0) {
  filtered.effects = node.effects.map((effect) => {
    var processedEffect = Object.assign({}, effect);
    if (processedEffect.color) {
      processedEffect.color = rgbaToHex(processedEffect.color);
    }
    return processedEffect;
  });
}
```

## Effects Supported
- `DROP_SHADOW`
- `INNER_SHADOW`
- `LAYER_BLUR`
- `BACKGROUND_BLUR`

## Impact
`get_node_info` now returns effects data for nodes with drop shadows, inner shadows, layer blur, and background blur.