### PR TITLE
feat: add set_gradient_fill, set_drop_shadow, set_layer_blur tools

### DIFF
--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -135,6 +135,12 @@ async function handleCommand(command, params) {
       return await setFillColor(params);
     case "set_stroke_color":
       return await setStrokeColor(params);
+    case "set_gradient_fill":
+      return await setGradientFill(params);
+    case "set_drop_shadow":
+      return await setDropShadow(params);
+    case "set_layer_blur":
+      return await setLayerBlur(params);
     case "move_node":
       return await moveNode(params);
     case "resize_node":
@@ -955,6 +961,135 @@ async function setFillColor(params) {
     name: node.name,
     fills: [paintStyle],
   };
+}
+
+// ───────────────────── Gradient Fill ─────────────────────
+async function setGradientFill(params) {
+  const { nodeId, type, stops, angle = 180 } = params || {};
+  if (!nodeId) throw new Error("Missing nodeId");
+  if (!Array.isArray(stops) || stops.length < 2)
+    throw new Error("Need at least 2 gradient stops");
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) throw new Error(`Node not found: ${nodeId}`);
+  if (!("fills" in node)) throw new Error(`Node does not support fills: ${nodeId}`);
+
+  const typeMap = {
+    linear: "GRADIENT_LINEAR",
+    radial: "GRADIENT_RADIAL",
+    angular: "GRADIENT_ANGULAR",
+    diamond: "GRADIENT_DIAMOND",
+  };
+  const gradientType = typeMap[type] || "GRADIENT_LINEAR";
+
+  // angle (deg) → 2x3 transform matrix. 180 = top→bottom, 90 = left→right
+  const rad = ((angle - 90) * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const transform = [
+    [cos, sin, (1 - cos - sin) / 2],
+    [-sin, cos, (1 + sin - cos) / 2],
+  ];
+
+  const gradientStops = stops.map((s) => ({
+    position: parseFloat(s.position) || 0,
+    color: {
+      r: parseFloat(s.r) || 0,
+      g: parseFloat(s.g) || 0,
+      b: parseFloat(s.b) || 0,
+      a: s.a == null ? 1 : parseFloat(s.a),
+    },
+  }));
+
+  const paint = {
+    type: gradientType,
+    gradientTransform: transform,
+    gradientStops,
+  };
+
+  node.fills = [paint];
+
+  return {
+    id: node.id,
+    name: node.name,
+    fillType: gradientType,
+    stopCount: gradientStops.length,
+  };
+}
+
+// ───────────────────── Drop Shadow ─────────────────────
+async function setDropShadow(params) {
+  const {
+    nodeId,
+    offsetX = 0,
+    offsetY = 0,
+    radius = 0,
+    spread = 0,
+    color = { r: 0, g: 0, b: 0, a: 0.25 },
+    inner = false,
+  } = params || {};
+  if (!nodeId) throw new Error("Missing nodeId");
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) throw new Error(`Node not found: ${nodeId}`);
+  if (!("effects" in node)) throw new Error(`Node does not support effects: ${nodeId}`);
+
+  const effect = {
+    type: inner ? "INNER_SHADOW" : "DROP_SHADOW",
+    color: {
+      r: parseFloat(color.r) || 0,
+      g: parseFloat(color.g) || 0,
+      b: parseFloat(color.b) || 0,
+      a: color.a == null ? 0.25 : parseFloat(color.a),
+    },
+    offset: { x: parseFloat(offsetX) || 0, y: parseFloat(offsetY) || 0 },
+    radius: parseFloat(radius) || 0,
+    spread: parseFloat(spread) || 0,
+    visible: true,
+    blendMode: "NORMAL",
+    showShadowBehindNode: false,
+  };
+
+  // Preserve existing non-shadow effects (blurs), replace shadow effects
+  const existing = (node.effects || []).filter(
+    (e) => e.type !== "DROP_SHADOW" && e.type !== "INNER_SHADOW"
+  );
+  node.effects = [...existing, effect];
+
+  return { id: node.id, name: node.name, effect };
+}
+
+// ───────────────────── Layer Blur ─────────────────────
+async function setLayerBlur(params) {
+  const { nodeId, radius = 0, background = false } = params || {};
+  if (!nodeId) throw new Error("Missing nodeId");
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) throw new Error(`Node not found: ${nodeId}`);
+  if (!("effects" in node)) throw new Error(`Node does not support effects: ${nodeId}`);
+
+  const blurType = background ? "BACKGROUND_BLUR" : "LAYER_BLUR";
+
+  // remove existing blur of any kind, keep shadows
+  const others = (node.effects || []).filter(
+    (e) => e.type !== "LAYER_BLUR" && e.type !== "BACKGROUND_BLUR"
+  );
+
+  if (radius <= 0) {
+    node.effects = others;
+    return { id: node.id, name: node.name, removed: true };
+  }
+
+  node.effects = [
+    ...others,
+    {
+      type: blurType,
+      radius: parseFloat(radius),
+      visible: true,
+    },
+  ];
+
+  return { id: node.id, name: node.name, blurType, radius };
 }
 
 async function setStrokeColor(params) {

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -679,6 +679,160 @@ server.tool(
   }
 );
 
+// Set Gradient Fill Tool
+server.tool(
+  "set_gradient_fill",
+  "Set a gradient fill on a node in Figma. Supports linear, radial, angular, diamond gradients with 2+ color stops.",
+  {
+    nodeId: z.string().describe("The ID of the node to modify"),
+    type: z
+      .enum(["linear", "radial", "angular", "diamond"])
+      .describe("Gradient type"),
+    stops: z
+      .array(
+        z.object({
+          position: z.number().min(0).max(1).describe("Stop position (0-1)"),
+          r: z.number().min(0).max(1),
+          g: z.number().min(0).max(1),
+          b: z.number().min(0).max(1),
+          a: z.number().min(0).max(1).optional(),
+        })
+      )
+      .min(2)
+      .describe("Color stops (at least 2)"),
+    angle: z
+      .number()
+      .optional()
+      .describe(
+        "Angle in degrees for linear gradient (0=top→bottom, 90=left→right). Default 180."
+      ),
+  },
+  async ({ nodeId, type, stops, angle }: any) => {
+    try {
+      const result = await sendCommandToFigma("set_gradient_fill", {
+        nodeId,
+        type,
+        stops,
+        angle: angle ?? 180,
+      });
+      const typedResult = result as { name: string };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Set ${type} gradient (${stops.length} stops) on node "${typedResult.name}"`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error setting gradient fill: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Set Drop Shadow Tool
+server.tool(
+  "set_drop_shadow",
+  "Add a drop shadow effect to a node in Figma. Replaces existing effects.",
+  {
+    nodeId: z.string().describe("The ID of the node to modify"),
+    offsetX: z.number().describe("Shadow X offset"),
+    offsetY: z.number().describe("Shadow Y offset"),
+    radius: z.number().min(0).describe("Blur radius"),
+    spread: z.number().optional().describe("Spread (default 0)"),
+    r: z.number().min(0).max(1).describe("Shadow color R (0-1)"),
+    g: z.number().min(0).max(1).describe("Shadow color G (0-1)"),
+    b: z.number().min(0).max(1).describe("Shadow color B (0-1)"),
+    a: z.number().min(0).max(1).describe("Shadow color A / opacity (0-1)"),
+    inner: z
+      .boolean()
+      .optional()
+      .describe("True for INNER_SHADOW, false (default) for DROP_SHADOW"),
+  },
+  async ({ nodeId, offsetX, offsetY, radius, spread, r, g, b, a, inner }: any) => {
+    try {
+      const result = await sendCommandToFigma("set_drop_shadow", {
+        nodeId,
+        offsetX,
+        offsetY,
+        radius,
+        spread: spread ?? 0,
+        color: { r, g, b, a },
+        inner: !!inner,
+      });
+      const typedResult = result as { name: string };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Set ${inner ? "inner" : "drop"} shadow on node "${typedResult.name}" — offset (${offsetX}, ${offsetY}), blur ${radius}, color rgba(${r}, ${g}, ${b}, ${a})`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error setting drop shadow: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Set Layer Blur Tool
+server.tool(
+  "set_layer_blur",
+  "Apply a layer blur effect to a node in Figma. Use radius 0 to remove existing blur.",
+  {
+    nodeId: z.string().describe("The ID of the node to modify"),
+    radius: z.number().min(0).describe("Blur radius (0 to remove)"),
+    background: z
+      .boolean()
+      .optional()
+      .describe("True for BACKGROUND_BLUR (frosted glass), false (default) for LAYER_BLUR"),
+  },
+  async ({ nodeId, radius, background }: any) => {
+    try {
+      const result = await sendCommandToFigma("set_layer_blur", {
+        nodeId,
+        radius,
+        background: !!background,
+      });
+      const typedResult = result as { name: string };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Set ${background ? "background" : "layer"} blur on node "${typedResult.name}" — radius ${radius}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error setting blur: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
 // Move Node Tool
 server.tool(
   "move_node",
@@ -2623,6 +2777,9 @@ type FigmaCommand =
   | "create_text"
   | "set_fill_color"
   | "set_stroke_color"
+  | "set_gradient_fill"
+  | "set_drop_shadow"
+  | "set_layer_blur"
   | "move_node"
   | "resize_node"
   | "delete_node"
@@ -2702,6 +2859,26 @@ type CommandParams = {
     b: number;
     a?: number;
     weight?: number;
+  };
+  set_gradient_fill: {
+    nodeId: string;
+    type: "linear" | "radial" | "angular" | "diamond";
+    stops: Array<{ position: number; r: number; g: number; b: number; a?: number }>;
+    angle?: number;
+  };
+  set_drop_shadow: {
+    nodeId: string;
+    offsetX: number;
+    offsetY: number;
+    radius: number;
+    spread?: number;
+    color: { r: number; g: number; b: number; a: number };
+    inner?: boolean;
+  };
+  set_layer_blur: {
+    nodeId: string;
+    radius: number;
+    background?: boolean;
   };
   move_node: {
     nodeId: string;


### PR DESCRIPTION
 ## Summary                                                                                                               
                                                                                                                           
  Adds 3 new MCP tools that expose Figma's existing gradient fill and effects APIs:                                        
                                                                                                                           
  - **`set_gradient_fill`** — apply linear / radial / angular / diamond gradients with 2+ color stops and optional angle   
  - **`set_drop_shadow`** — add drop or inner shadow (offset, radius, spread, RGBA); preserves existing blur               
  - **`set_layer_blur`** — apply layer blur or background blur (frosted glass); preserves existing shadows
                                                                                                                           
  ## Motivation                                                
                                                                                                                           
  The current toolset covers solid fills and strokes, but modern AI / SaaS product UIs lean heavily on gradients, soft     
  shadows, and background blur for elevation and glassmorphism. Without these tools the MCP can't faithfully recreate Hi-Fi
   designs — every `box-shadow` and `radial-gradient(...)` ends up as a flat rectangle.                                    
                                                                                                                           
  Figma supports all of this natively via `node.fills` and `node.effects` — these are thin wrappers around the existing
  Plugin API.                                                                                                              
                                                               
  ## Changes                                                                                                               
   
  - `src/talk_to_figma_mcp/server.ts` — 3 tool registrations, 3 entries each in `FigmaCommand` union and `CommandParams`   
  type                                                         
  - `src/cursor_mcp_plugin/code.js` — 3 cases in `handleCommand` switch, 3 new async handlers
                                                                                                                           
  Net: ~280 lines added, no breaking changes, all existing tools unchanged.
                                                                                                                           
  ## Examples                                                                                                              
                                                                                                                           
  ```js                                                                                                                    
  set_gradient_fill({                                                                                                      
    nodeId: "1:2",                                             
    type: "radial",                           
    stops: [                              
      { position: 0, r: 1, g: 0.67, b: 0.97 },
      { position: 1, r: 0.2, g: 0.37, b: 1 }                                                                               
    ]                                     
  })                                                                                                                       
                                                                                                                           
  set_drop_shadow({
    nodeId: "1:3",                                                                                                         
    offsetX: 0, offsetY: 12, radius: 24,                       
    r: 0.89, g: 0.07, b: 0.122, a: 0.35       
  })                                          
                                          
  set_layer_blur({                                                                                                         
    nodeId: "1:4",                                                                                                         
    radius: 20,                                                                                                            
    background: true                                                                                                       
  })                                                           

  Test plan                                                                                                                
  
  - Built locally with bun run build                                                                                       
  - Verified all 3 tools work in Figma desktop against a test file (gradient rectangle, shadowed button, glass card)
  - Existing tools unchanged — regression-free