### PR TITLE
feat: add variable binding tools for fills and strokes

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ The MCP server provides the following tools for interacting with Figma:
 - `set_stroke_color` - Set the stroke color and weight of a node
 - `set_corner_radius` - Set the corner radius of a node with optional per-corner control
 
+### Variables (Design Tokens)
+
+- `get_local_variable_collections` - List local variable collections with their modes and variable IDs
+- `get_local_variables` - List local variables, optionally filtered by resolved type (`COLOR`, `FLOAT`, `STRING`, `BOOLEAN`) or collection ID
+- `set_fill_variable` - Bind an existing `COLOR` variable to a node's fill (preserves the design-system link instead of baking in a raw color)
+- `set_stroke_variable` - Bind an existing `COLOR` variable to a node's stroke
+
 ### Layout & Organization
 
 - `move_node` - Move a node to a new position

--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -135,6 +135,14 @@ async function handleCommand(command, params) {
       return await setFillColor(params);
     case "set_stroke_color":
       return await setStrokeColor(params);
+    case "get_local_variables":
+      return await getLocalVariables(params);
+    case "get_local_variable_collections":
+      return await getLocalVariableCollections();
+    case "set_fill_variable":
+      return await setFillVariable(params);
+    case "set_stroke_variable":
+      return await setStrokeVariable(params);
     case "move_node":
       return await moveNode(params);
     case "resize_node":
@@ -1008,6 +1016,138 @@ async function setStrokeColor(params) {
     name: node.name,
     strokes: node.strokes,
     strokeWeight: "strokeWeight" in node ? node.strokeWeight : undefined,
+  };
+}
+
+async function getLocalVariableCollections() {
+  const collections = await figma.variables.getLocalVariableCollectionsAsync();
+  return collections.map((c) => ({
+    id: c.id,
+    name: c.name,
+    key: c.key,
+    modes: c.modes.map((m) => ({ modeId: m.modeId, name: m.name })),
+    defaultModeId: c.defaultModeId,
+    variableIds: c.variableIds,
+  }));
+}
+
+async function getLocalVariables(params) {
+  const { resolvedType, collectionId } = params || {};
+  let variables = await figma.variables.getLocalVariablesAsync(resolvedType);
+  if (collectionId) {
+    variables = variables.filter((v) => v.variableCollectionId === collectionId);
+  }
+  return variables.map((v) => ({
+    id: v.id,
+    name: v.name,
+    key: v.key,
+    resolvedType: v.resolvedType,
+    variableCollectionId: v.variableCollectionId,
+    valuesByMode: v.valuesByMode,
+    description: v.description,
+    scopes: v.scopes,
+  }));
+}
+
+async function setFillVariable(params) {
+  const { nodeId, variableId, fillIndex = 0 } = params || {};
+
+  if (!nodeId) throw new Error("Missing nodeId parameter");
+  if (!variableId) throw new Error("Missing variableId parameter");
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) throw new Error(`Node not found with ID: ${nodeId}`);
+  if (!("fills" in node)) throw new Error(`Node does not support fills: ${nodeId}`);
+
+  const variable = await figma.variables.getVariableByIdAsync(variableId);
+  if (!variable) throw new Error(`Variable not found with ID: ${variableId}`);
+  if (variable.resolvedType !== "COLOR") {
+    throw new Error(
+      `Variable must be of type COLOR to bind to a fill (got ${variable.resolvedType})`
+    );
+  }
+
+  const existing = node.fills;
+  if (existing === figma.mixed) {
+    throw new Error("Node has mixed fills; specify a single fill first");
+  }
+  const fills = Array.isArray(existing) ? existing.slice() : [];
+  if (fills.length === 0) {
+    fills.push({ type: "SOLID", color: { r: 0, g: 0, b: 0 }, opacity: 1 });
+  }
+  const target = fills[fillIndex];
+  if (!target) {
+    throw new Error(`No fill at index ${fillIndex} on node ${nodeId}`);
+  }
+  if (target.type !== "SOLID") {
+    throw new Error(
+      `Fill at index ${fillIndex} is ${target.type}; only SOLID fills support color variable binding`
+    );
+  }
+
+  fills[fillIndex] = figma.variables.setBoundVariableForPaint(
+    target,
+    "color",
+    variable
+  );
+  node.fills = fills;
+
+  return {
+    id: node.id,
+    name: node.name,
+    fills: node.fills,
+    boundVariable: { id: variable.id, name: variable.name },
+  };
+}
+
+async function setStrokeVariable(params) {
+  const { nodeId, variableId, strokeIndex = 0 } = params || {};
+
+  if (!nodeId) throw new Error("Missing nodeId parameter");
+  if (!variableId) throw new Error("Missing variableId parameter");
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) throw new Error(`Node not found with ID: ${nodeId}`);
+  if (!("strokes" in node)) throw new Error(`Node does not support strokes: ${nodeId}`);
+
+  const variable = await figma.variables.getVariableByIdAsync(variableId);
+  if (!variable) throw new Error(`Variable not found with ID: ${variableId}`);
+  if (variable.resolvedType !== "COLOR") {
+    throw new Error(
+      `Variable must be of type COLOR to bind to a stroke (got ${variable.resolvedType})`
+    );
+  }
+
+  const existing = node.strokes;
+  if (existing === figma.mixed) {
+    throw new Error("Node has mixed strokes; specify a single stroke first");
+  }
+  const strokes = Array.isArray(existing) ? existing.slice() : [];
+  if (strokes.length === 0) {
+    strokes.push({ type: "SOLID", color: { r: 0, g: 0, b: 0 }, opacity: 1 });
+  }
+  const target = strokes[strokeIndex];
+  if (!target) {
+    throw new Error(`No stroke at index ${strokeIndex} on node ${nodeId}`);
+  }
+  if (target.type !== "SOLID") {
+    throw new Error(
+      `Stroke at index ${strokeIndex} is ${target.type}; only SOLID strokes support color variable binding`
+    );
+  }
+
+  strokes[strokeIndex] = figma.variables.setBoundVariableForPaint(
+    target,
+    "color",
+    variable
+  );
+  node.strokes = strokes;
+
+  return {
+    id: node.id,
+    name: node.name,
+    strokes: node.strokes,
+    boundVariable: { id: variable.id, name: variable.name },
   };
 }
 

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -679,6 +679,170 @@ server.tool(
   }
 );
 
+// Get Local Variable Collections Tool
+server.tool(
+  "get_local_variable_collections",
+  "List all local variable collections in the current Figma file, with their modes and variable IDs. Useful for discovering design tokens before binding.",
+  {},
+  async () => {
+    try {
+      const result = await sendCommandToFigma("get_local_variable_collections", {});
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting variable collections: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Get Local Variables Tool
+server.tool(
+  "get_local_variables",
+  "List local variables (design tokens) in the current Figma file. Optionally filter by resolved type (COLOR, FLOAT, STRING, BOOLEAN) or collection ID.",
+  {
+    resolvedType: z
+      .enum(["BOOLEAN", "COLOR", "FLOAT", "STRING"])
+      .optional()
+      .describe("Optional filter: only return variables of this resolved type"),
+    collectionId: z
+      .string()
+      .optional()
+      .describe("Optional filter: only variables from this collection ID"),
+  },
+  async ({ resolvedType, collectionId }: any) => {
+    try {
+      const result = await sendCommandToFigma("get_local_variables", {
+        resolvedType,
+        collectionId,
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting variables: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Set Fill Variable Tool
+server.tool(
+  "set_fill_variable",
+  "Bind an existing COLOR variable to a node's fill. Prefer this over set_fill_color when the design uses tokens/variables so the fill stays connected to the design system.",
+  {
+    nodeId: z.string().describe("The ID of the node whose fill should be bound"),
+    variableId: z
+      .string()
+      .describe("The ID of the COLOR variable to bind (from get_local_variables)"),
+    fillIndex: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe("Index of the fill to bind (default 0). Creates a default SOLID fill at index 0 if the node has no fills."),
+  },
+  async ({ nodeId, variableId, fillIndex }: any) => {
+    try {
+      const result = await sendCommandToFigma("set_fill_variable", {
+        nodeId,
+        variableId,
+        fillIndex,
+      });
+      const typedResult = result as { name: string; boundVariable: { name: string } };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Bound variable "${typedResult.boundVariable.name}" to fill${fillIndex ? ` [${fillIndex}]` : ""} of node "${typedResult.name}"`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error binding fill variable: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Set Stroke Variable Tool
+server.tool(
+  "set_stroke_variable",
+  "Bind an existing COLOR variable to a node's stroke. Prefer this over set_stroke_color when the design uses tokens/variables.",
+  {
+    nodeId: z.string().describe("The ID of the node whose stroke should be bound"),
+    variableId: z
+      .string()
+      .describe("The ID of the COLOR variable to bind (from get_local_variables)"),
+    strokeIndex: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe("Index of the stroke to bind (default 0)"),
+  },
+  async ({ nodeId, variableId, strokeIndex }: any) => {
+    try {
+      const result = await sendCommandToFigma("set_stroke_variable", {
+        nodeId,
+        variableId,
+        strokeIndex,
+      });
+      const typedResult = result as { name: string; boundVariable: { name: string } };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Bound variable "${typedResult.boundVariable.name}" to stroke${strokeIndex ? ` [${strokeIndex}]` : ""} of node "${typedResult.name}"`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error binding stroke variable: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
 // Move Node Tool
 server.tool(
   "move_node",
@@ -2623,6 +2787,10 @@ type FigmaCommand =
   | "create_text"
   | "set_fill_color"
   | "set_stroke_color"
+  | "get_local_variables"
+  | "get_local_variable_collections"
+  | "set_fill_variable"
+  | "set_stroke_variable"
   | "move_node"
   | "resize_node"
   | "delete_node"
@@ -2702,6 +2870,21 @@ type CommandParams = {
     b: number;
     a?: number;
     weight?: number;
+  };
+  get_local_variables: {
+    resolvedType?: "BOOLEAN" | "COLOR" | "FLOAT" | "STRING";
+    collectionId?: string;
+  };
+  get_local_variable_collections: Record<string, never>;
+  set_fill_variable: {
+    nodeId: string;
+    variableId: string;
+    fillIndex?: number;
+  };
+  set_stroke_variable: {
+    nodeId: string;
+    variableId: string;
+    strokeIndex?: number;
   };
   move_node: {
     nodeId: string;


### PR DESCRIPTION
Expose the Figma variables (design tokens) API through four new MCP tools:

- get_local_variable_collections: list collections with their modes and variable IDs
- get_local_variables: list variables with optional filter by resolvedType or collection
- set_fill_variable: bind an existing COLOR variable to a node's fill
- set_stroke_variable: bind an existing COLOR variable to a node's stroke

Previously, set_fill_color and set_stroke_color only accepted raw RGBA values, so designs produced via the MCP couldn't stay connected to a design system's tokens. These tools let agents preserve the design-token link by binding variables (the "variable chip" shown in Figma's Fill/Stroke panel) instead of baking in hex values.

Plugin side uses figma.variables.setBoundVariableForPaint on SOLID paints and falls back to creating a default SOLID fill if the node has none. The MCP server follows the existing tool-registration and command-dispatch patterns.