### PR TITLE
feat: add --insecure flag to force plain ws:// for remote hosts

### DIFF
--- a/dist/server.js
+++ b/dist/server.js
@@ -28,7 +28,8 @@ var server = new McpServer({
 var args = process.argv.slice(2);
 var serverArg = args.find((arg) => arg.startsWith("--server="));
 var serverUrl = serverArg ? serverArg.split("=")[1] : "localhost";
-var WS_URL = serverUrl === "localhost" ? `ws://${serverUrl}` : `wss://${serverUrl}`;
+var insecure = args.includes("--insecure");
+var WS_URL = (serverUrl === "localhost" || insecure) ? `ws://${serverUrl}` : `wss://${serverUrl}`;
 server.tool(
   "get_document_info",
   "Get detailed information about the current Figma document",


### PR DESCRIPTION
When connecting to a non-localhost server, the MCP client unconditionally used wss://, which broke connections to plain (non-TLS) WebSocket bridges on LAN or remote hosts.

This PR introduces an --insecure flag that forces ws:// regardless of the host, while keeping the existing behavior (wss:// for remote, ws:// for localhost) when the flag is absent.

Usage:

`cursor-talk-to-figma-mcp --server=192.168.1.80:3055 --insecure`