### PR TITLE
Add npm package source metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "cursor-talk-to-figma-mcp",
   "description": "Cursor Talk to Figma MCP",
   "version": "0.3.5",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/grab/cursor-talk-to-figma-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/grab/cursor-talk-to-figma-mcp/issues"
+  },
+  "homepage": "https://github.com/grab/cursor-talk-to-figma-mcp#readme",
   "module": "dist/server.js",
   "main": "dist/server.js",
   "bin": {


### PR DESCRIPTION
## Summary
- add npm package source metadata for repository, issue tracker, and homepage
- keep the change scoped to package.json metadata only

## Validation
- checked published npm metadata for cursor-talk-to-figma-mcp@0.3.5
- parsed package.json successfully after the edit
- verified repository, bugs, and homepage values point to this public repo