### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Add the server to your Cursor MCP configuration in `~/.cursor/mcp.json`:
 }
 ```
 
+### MCP Server: Integration with Autohand Code
+
+Add the published server from the command line:
+
+```bash
+autohand mcp add TalkToFigma bunx cursor-talk-to-figma-mcp@latest
+```
+
+Add `--scope project` after `add` to keep the server configuration in the current project. See [Autohand Code](https://github.com/autohandai/code-cli/) for current installation and CLI details.
+
 ### WebSocket Server
 
 Start the WebSocket server:


### PR DESCRIPTION
## What changed

Adds a short Autohand Code command after the existing Cursor MCP configuration. It uses the same published `bunx cursor-talk-to-figma-mcp@latest` entry point already documented by the project.

The note also shows how to keep the MCP registration project-scoped.

## Verification

- Checked the command against the current Autohand Code MCP CLI
- Ran `git diff --check`

This is a documentation-only change.
