### PR TITLE
feat: add set_hyperlink tool for text nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The MCP server provides the following tools for interacting with Figma:
 - `scan_text_nodes` - Scan text nodes with intelligent chunking for large designs
 - `set_text_content` - Set the text content of a single text node
 - `set_multiple_text_contents` - Batch update multiple text nodes efficiently
+- `set_hyperlink` - Set or clear a hyperlink on a range of a text node (whole node by default)
 
 ### Auto Layout & Spacing
 

--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -182,6 +182,8 @@ async function handleCommand(command, params) {
       return await setMultipleTextContents(params);
     case "get_annotations":
       return await getAnnotations(params);
+    case "set_hyperlink":
+      return await setHyperlink(params);
     case "set_annotation":
       return await setAnnotation(params);
     case "scan_nodes_by_types":
@@ -1482,6 +1484,38 @@ async function setTextContent(params) {
   } catch (error) {
     throw new Error(`Error setting text content: ${error.message}`);
   }
+}
+
+// Set a hyperlink on a range of a text node (whole node by default).
+async function setHyperlink(params) {
+  const { nodeId, url, rangeStart, rangeEnd } = params || {};
+  if (!nodeId) throw new Error("Missing nodeId parameter");
+  if (!url) throw new Error("Missing url parameter");
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) throw new Error(`Node not found with ID: ${nodeId}`);
+  if (node.type !== "TEXT") throw new Error(`Node is not a text node: ${nodeId}`);
+
+  // Fonts must be loaded before mutating text ranges (incl. hyperlinks).
+  const fontName = node.fontName;
+  if (fontName === figma.mixed) {
+    const fonts = node.getRangeAllFontNames(0, node.characters.length);
+    for (const f of fonts) await figma.loadFontAsync(f);
+  } else {
+    await figma.loadFontAsync(fontName);
+  }
+
+  const start = typeof rangeStart === "number" ? rangeStart : 0;
+  const end = typeof rangeEnd === "number" ? rangeEnd : node.characters.length;
+
+  if (url === "") {
+    // Empty url clears the hyperlink on the range.
+    node.setRangeHyperlink(start, end, null);
+    return { id: node.id, name: node.name, url: null, start, end };
+  }
+
+  node.setRangeHyperlink(start, end, { type: "URL", value: url });
+  return { id: node.id, name: node.name, url, start, end };
 }
 
 // Initialize settings on load

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -932,6 +932,57 @@ server.tool(
   }
 );
 
+// Set Hyperlink Tool
+server.tool(
+  "set_hyperlink",
+  "Set (or clear) a hyperlink on a range of a text node. Links the whole text by default; pass rangeStart/rangeEnd for a substring. An empty url clears the hyperlink.",
+  {
+    nodeId: z.string().describe("The ID of the text node to modify"),
+    url: z
+      .string()
+      .describe("The URL to link to. Pass an empty string to clear the hyperlink."),
+    rangeStart: z
+      .number()
+      .optional()
+      .describe("Start character index of the range (default: 0)"),
+    rangeEnd: z
+      .number()
+      .optional()
+      .describe("End character index of the range (default: end of text)"),
+  },
+  async ({ nodeId, url, rangeStart, rangeEnd }: any) => {
+    try {
+      const result = await sendCommandToFigma("set_hyperlink", {
+        nodeId,
+        url,
+        rangeStart,
+        rangeEnd,
+      });
+      const typedResult = result as { name: string; url: string | null };
+      return {
+        content: [
+          {
+            type: "text",
+            text: typedResult.url
+              ? `Set hyperlink on node "${typedResult.name}" to "${typedResult.url}"`
+              : `Cleared hyperlink on node "${typedResult.name}"`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error setting hyperlink: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
 // Get Styles Tool
 server.tool(
   "get_styles",
@@ -2637,6 +2688,7 @@ type FigmaCommand =
   | "set_corner_radius"
   | "clone_node"
   | "set_text_content"
+  | "set_hyperlink"
   | "scan_text_nodes"
   | "set_multiple_text_contents"
   | "get_annotations"
@@ -2758,6 +2810,12 @@ type CommandParams = {
   set_text_content: {
     nodeId: string;
     text: string;
+  };
+  set_hyperlink: {
+    nodeId: string;
+    url: string;
+    rangeStart?: number;
+    rangeEnd?: number;
   };
   scan_text_nodes: {
     nodeId: string;


### PR DESCRIPTION
## What

Adds a `set_hyperlink` MCP tool that applies (or clears) a hyperlink on a range of a text node, using the Figma Plugin API's `setRangeHyperlink`.

- Links the **whole text by default**; pass `rangeStart` / `rangeEnd` to target a substring.
- An **empty `url` clears** the hyperlink on the range.
- Handles mixed-font text nodes (loads every range font before mutating).

## Why

There was no way to add clickable links to text via this MCP. Handy for FigJam/Design boards where cards or nodes should deep-link to an external tracker — e.g. visualizing Linear/Jira issues on a FigJam board where each card title links back to its issue.

## Changes

- **plugin** (`src/cursor_mcp_plugin/code.js`): `set_hyperlink` command handler + font loading (incl. `figma.mixed`).
- **server** (`src/talk_to_figma_mcp/server.ts`): `set_hyperlink` tool registration + command type + params.
- **README**: document the new tool.

Source-only changes (no `dist/` rebuild — `dist/` is gitignored).

## Testing

Verified end-to-end against a live FigJam board: applied `set_hyperlink` to 18 text nodes; each became a clickable link. `node --check` passes on the plugin and `bun run build` compiles the server cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)