### PR TITLE
feat: add set_image_fill, create_section, set_parent, rename_node

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The MCP server provides the following tools for interacting with Figma:
 
 - `create_rectangle` - Create a new rectangle with position, size, and optional name
 - `create_frame` - Create a new frame with position, size, and optional name
+- `create_section` - Create a section to group related content on the canvas
 - `create_text` - Create a new text node with customizable font properties
 
 ### Modifying text content
@@ -174,6 +175,7 @@ The MCP server provides the following tools for interacting with Figma:
 - `set_fill_color` - Set the fill color of a node (RGBA)
 - `set_stroke_color` - Set the stroke color and weight of a node
 - `set_corner_radius` - Set the corner radius of a node with optional per-corner control
+- `set_image_fill` - Fill a node with an image from a local file path, URL, or base64 data (FILL, FIT, CROP, or TILE)
 
 ### Layout & Organization
 
@@ -182,6 +184,8 @@ The MCP server provides the following tools for interacting with Figma:
 - `delete_node` - Delete a node
 - `delete_multiple_nodes` - Delete multiple nodes at once efficiently
 - `clone_node` - Create a copy of an existing node with optional position offset
+- `rename_node` - Rename a node
+- `set_parent` - Move a node into a new parent (section, frame or group), preserving its absolute position by default
 
 ### Components & Styles
 

--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -254,6 +254,14 @@ async function handleCommand(command, params) {
       return await setFocus(params);
     case "set_selections":
       return await setSelections(params);
+    case "set_image_fill":
+      return await setImageFill(params);
+    case "rename_node":
+      return await renameNode(params);
+    case "create_section":
+      return await createSection(params);
+    case "set_parent":
+      return await setParent(params);
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -1025,6 +1033,222 @@ async function setStrokeColor(params) {
     name: node.name,
     strokes: node.strokes,
     strokeWeight: "strokeWeight" in node ? node.strokeWeight : undefined,
+  };
+}
+
+async function setImageFill(params) {
+  const { nodeId, imageBase64, scaleMode = "FILL" } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  if (!imageBase64) {
+    throw new Error("Missing imageBase64 parameter");
+  }
+
+  const validScaleModes = ["FILL", "FIT", "CROP", "TILE"];
+  if (validScaleModes.indexOf(scaleMode) === -1) {
+    throw new Error(
+      `Invalid scaleMode: ${scaleMode}. Must be one of: ${validScaleModes.join(", ")}`
+    );
+  }
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) {
+    throw new Error(`Node not found with ID: ${nodeId}`);
+  }
+
+  if (!("fills" in node)) {
+    throw new Error(`Node does not support fills: ${nodeId}`);
+  }
+
+  const bytes = base64ToUint8Array(imageBase64);
+
+  let image;
+  try {
+    image = figma.createImage(bytes);
+  } catch (error) {
+    throw new Error(
+      `Figma rejected the image (supported: PNG/JPG/GIF/WEBP up to 4096x4096): ${error.message}`
+    );
+  }
+
+  node.fills = [
+    {
+      type: "IMAGE",
+      imageHash: image.hash,
+      scaleMode: scaleMode,
+    },
+  ];
+
+  let imageWidth;
+  let imageHeight;
+  try {
+    const size = await image.getSizeAsync();
+    imageWidth = size.width;
+    imageHeight = size.height;
+  } catch (sizeError) {
+    // Size lookup is informational only
+  }
+
+  return {
+    id: node.id,
+    name: node.name,
+    imageHash: image.hash,
+    scaleMode: scaleMode,
+    imageWidth: imageWidth,
+    imageHeight: imageHeight,
+  };
+}
+
+// Decode base64 in the plugin sandbox, where atob is not available
+function base64ToUint8Array(base64) {
+  if (typeof figma.base64Decode === "function") {
+    return figma.base64Decode(base64);
+  }
+
+  const base64Chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  const clean = base64.replace(/[^A-Za-z0-9+/]/g, "");
+  const length = clean.length;
+  const bytes = new Uint8Array(Math.floor((length * 3) / 4));
+
+  let byteIndex = 0;
+  for (let i = 0; i < length; i += 4) {
+    const a = base64Chars.indexOf(clean[i]);
+    const b = base64Chars.indexOf(clean[i + 1]);
+    const c = base64Chars.indexOf(clean[i + 2]);
+    const d = base64Chars.indexOf(clean[i + 3]);
+
+    bytes[byteIndex++] = (a << 2) | (b >> 4);
+    if (c !== -1) bytes[byteIndex++] = ((b & 15) << 4) | (c >> 2);
+    if (d !== -1) bytes[byteIndex++] = ((c & 3) << 6) | d;
+  }
+
+  return bytes.slice(0, byteIndex);
+}
+
+async function renameNode(params) {
+  const { nodeId, name } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  if (name === undefined || name === null) {
+    throw new Error("Missing name parameter");
+  }
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) {
+    throw new Error(`Node not found with ID: ${nodeId}`);
+  }
+
+  const previousName = node.name;
+  try {
+    node.name = String(name);
+  } catch (error) {
+    throw new Error(`Cannot rename node: ${error.message}`);
+  }
+
+  return {
+    id: node.id,
+    previousName: previousName,
+    name: node.name,
+  };
+}
+
+async function createSection(params) {
+  const {
+    x = 0,
+    y = 0,
+    width = 100,
+    height = 100,
+    name = "Section",
+  } = params || {};
+
+  const section = figma.createSection();
+  section.name = name;
+  section.x = x;
+  section.y = y;
+  section.resizeWithoutConstraints(width, height);
+
+  return {
+    id: section.id,
+    name: section.name,
+    x: section.x,
+    y: section.y,
+    width: section.width,
+    height: section.height,
+  };
+}
+
+async function setParent(params) {
+  const { nodeId, parentId, x, y, index } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  if (!parentId) {
+    throw new Error("Missing parentId parameter");
+  }
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) {
+    throw new Error(`Node not found with ID: ${nodeId}`);
+  }
+
+  const parentNode = await figma.getNodeByIdAsync(parentId);
+  if (!parentNode) {
+    throw new Error(`Parent node not found with ID: ${parentId}`);
+  }
+
+  if (!("appendChild" in parentNode)) {
+    throw new Error(`Parent node does not support children: ${parentId}`);
+  }
+
+  // Refuse to create a cycle
+  let ancestor = parentNode;
+  while (ancestor) {
+    if (ancestor.id === node.id) {
+      throw new Error("Cannot move a node into its own subtree");
+    }
+    ancestor = ancestor.parent;
+  }
+
+  // Capture the absolute position so it can be preserved across the move
+  const hasAbsolute = "absoluteTransform" in node;
+  const absoluteX = hasAbsolute ? node.absoluteTransform[0][2] : undefined;
+  const absoluteY = hasAbsolute ? node.absoluteTransform[1][2] : undefined;
+
+  if (index !== undefined) {
+    parentNode.insertChild(index, node);
+  } else {
+    parentNode.appendChild(node);
+  }
+
+  if (x !== undefined && y !== undefined) {
+    node.x = x;
+    node.y = y;
+  } else if (hasAbsolute && "x" in node) {
+    const parentAbsoluteX =
+      "absoluteTransform" in parentNode ? parentNode.absoluteTransform[0][2] : 0;
+    const parentAbsoluteY =
+      "absoluteTransform" in parentNode ? parentNode.absoluteTransform[1][2] : 0;
+    node.x = absoluteX - parentAbsoluteX;
+    node.y = absoluteY - parentAbsoluteY;
+  }
+
+  return {
+    id: node.id,
+    name: node.name,
+    parentId: parentNode.id,
+    parentName: parentNode.name,
+    x: "x" in node ? node.x : undefined,
+    y: "y" in node ? node.y : undefined,
+    index: parentNode.children.indexOf(node),
   };
 }
 

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -5,6 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import WebSocket from "ws";
 import { v4 as uuidv4 } from "uuid";
+import { readFile } from "fs/promises";
 
 // Define TypeScript interfaces for Figma responses
 interface FigmaResponse {
@@ -2652,7 +2653,11 @@ type FigmaCommand =
   | "set_default_connector"
   | "create_connections"
   | "set_focus"
-  | "set_selections";
+  | "set_selections"
+  | "set_image_fill"
+  | "rename_node"
+  | "create_section"
+  | "set_parent";
 
 type CommandParams = {
   get_document_info: Record<string, never>;
@@ -2800,6 +2805,29 @@ type CommandParams = {
   };
   set_selections: {
     nodeIds: string[];
+  };
+  set_image_fill: {
+    nodeId: string;
+    imageBase64: string;
+    scaleMode?: "FILL" | "FIT" | "CROP" | "TILE";
+  };
+  rename_node: {
+    nodeId: string;
+    name: string;
+  };
+  create_section: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    name?: string;
+  };
+  set_parent: {
+    nodeId: string;
+    parentId: string;
+    x?: number;
+    y?: number;
+    index?: number;
   };
 
 };
@@ -3032,6 +3060,231 @@ function sendCommandToFigma(
     ws.send(JSON.stringify(request));
   });
 }
+
+// Set Image Fill Tool
+server.tool(
+  "set_image_fill",
+  "Fill a node in Figma with an image from a local file path, a URL, or base64 data (replaces the node's existing fills)",
+  {
+    nodeId: z.string().describe("The ID of the node to fill"),
+    imagePath: z
+      .string()
+      .optional()
+      .describe(
+        "Absolute path to a local image file, read by the MCP server (preferred: keeps image bytes out of the model context)"
+      ),
+    imageUrl: z
+      .string()
+      .optional()
+      .describe(
+        "Image URL, fetched by the MCP server (the Figma plugin cannot fetch arbitrary domains itself)"
+      ),
+    imageBase64: z
+      .string()
+      .optional()
+      .describe(
+        "Base64-encoded image data, with or without a data: URI prefix (only when the image exists nowhere else)"
+      ),
+    scaleMode: z
+      .enum(["FILL", "FIT", "CROP", "TILE"])
+      .optional()
+      .describe("How the image fills the node (default: FILL)"),
+  },
+  async ({ nodeId, imagePath, imageUrl, imageBase64, scaleMode }: any) => {
+    try {
+      const sources = [imagePath, imageUrl, imageBase64].filter(
+        (source) => source !== undefined && source !== ""
+      );
+      if (sources.length !== 1) {
+        throw new Error("Provide exactly one of imagePath, imageUrl or imageBase64");
+      }
+
+      let base64Data: string;
+      if (imagePath) {
+        base64Data = (await readFile(imagePath)).toString("base64");
+      } else if (imageUrl) {
+        const response = await fetch(imageUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch image URL (HTTP ${response.status})`);
+        }
+        base64Data = Buffer.from(await response.arrayBuffer()).toString("base64");
+      } else {
+        base64Data = imageBase64.replace(/^data:[^;,]+;base64,/, "");
+      }
+
+      // Keep well under the websocket relay's default 16MB frame limit
+      if (base64Data.length > 12 * 1024 * 1024) {
+        throw new Error(
+          "Image is too large to send over the relay (~9MB binary max); downscale it first"
+        );
+      }
+
+      const result = await sendCommandToFigma("set_image_fill", {
+        nodeId,
+        imageBase64: base64Data,
+        scaleMode: scaleMode || "FILL",
+      });
+      const typedResult = result as {
+        name: string;
+        imageHash: string;
+        imageWidth?: number;
+        imageHeight?: number;
+      };
+      const sizeInfo = typedResult.imageWidth
+        ? ` (${typedResult.imageWidth}x${typedResult.imageHeight})`
+        : "";
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Set image fill of node "${typedResult.name}"${sizeInfo} with scale mode ${scaleMode || "FILL"
+              }, imageHash: ${typedResult.imageHash}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error setting image fill: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Rename Node Tool
+server.tool(
+  "rename_node",
+  "Rename a node in Figma",
+  {
+    nodeId: z.string().describe("The ID of the node to rename"),
+    name: z.string().describe("The new name for the node"),
+  },
+  async ({ nodeId, name }: any) => {
+    try {
+      const result = await sendCommandToFigma("rename_node", { nodeId, name });
+      const typedResult = result as { previousName: string; name: string };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Renamed node from "${typedResult.previousName}" to "${typedResult.name}"`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error renaming node: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Create Section Tool
+server.tool(
+  "create_section",
+  "Create a section in Figma to group related content on the canvas",
+  {
+    x: z.number().describe("X position"),
+    y: z.number().describe("Y position"),
+    width: z.number().describe("Width of the section"),
+    height: z.number().describe("Height of the section"),
+    name: z.string().optional().describe("Optional name for the section"),
+  },
+  async ({ x, y, width, height, name }: any) => {
+    try {
+      const result = await sendCommandToFigma("create_section", {
+        x,
+        y,
+        width,
+        height,
+        name: name || "Section",
+      });
+      const typedResult = result as { name: string; id: string };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Created section "${typedResult.name}" with ID: ${typedResult.id}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error creating section: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Set Parent Tool
+server.tool(
+  "set_parent",
+  "Move a node into a new parent node (e.g. a section, frame or group). Preserves the node's absolute position unless x/y are provided",
+  {
+    nodeId: z.string().describe("The ID of the node to move"),
+    parentId: z
+      .string()
+      .describe("The ID of the new parent node (must support children, e.g. a section, frame or group)"),
+    x: z.number().optional().describe("Optional X position relative to the new parent"),
+    y: z.number().optional().describe("Optional Y position relative to the new parent"),
+    index: z
+      .number()
+      .optional()
+      .describe("Optional child index to insert at (default: appended as last child)"),
+  },
+  async ({ nodeId, parentId, x, y, index }: any) => {
+    try {
+      const result = await sendCommandToFigma("set_parent", {
+        nodeId,
+        parentId,
+        x,
+        y,
+        index,
+      });
+      const typedResult = result as {
+        name: string;
+        parentName: string;
+        x?: number;
+        y?: number;
+      };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Moved node "${typedResult.name}" into "${typedResult.parentName}" at (${typedResult.x}, ${typedResult.y})`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error setting parent: ${error instanceof Error ? error.message : String(error)
+              }`,
+          },
+        ],
+      };
+    }
+  }
+);
 
 // Update the join_channel tool
 server.tool(


### PR DESCRIPTION
Adds four write tools that let an agent place bitmaps and organize the canvas — the missing pieces for image-driven workflows (e.g. dropping captured media into a template).

### Tools
- **`set_image_fill`** — fill a node with an image from a local **path**, a **URL**, or **base64**. The path/URL are resolved **server-side**, so only base64 ever crosses the relay and the plugin's `networkAccess` allowlist stays untouched (the plugin never fetches arbitrary domains). Plugin side: `figma.base64Decode` (with a hand-rolled fallback for older sandboxes) → `figma.createImage` → sets an `IMAGE` paint with the requested `scaleMode`. **Adapted from #130 by @Oreo-Mcflurry** — their branch rewrote `code.js` so it couldn't be cherry-picked cleanly, so the `createImage` approach is theirs, re-implemented against current `main` with URL/path fetching moved server-side.
- **`create_section`** — `figma.createSection()` + size, for grouping related content on the canvas.
- **`set_parent`** — reparent a node into a section/frame/group (with a cycle guard); preserves the node's absolute position unless `x`/`y` are given. Complements `move_node`, which is x/y-only and can't reparent.
- **`rename_node`** — rename any existing node (previously only newly-created nodes could be named).

### Notes
- **Source-only**, matching this repo's convention (`dist/` is rebuilt at version-bump time, not in feature PRs) — no build-artifact churn here.
- No optional chaining in the plugin code (kept compatible with the plugin sandbox).
- Verified end-to-end in Figma: image fills from all three sources, `create_section` + `set_parent` (absolute position preserved), `rename_node`, plus a full template-clone rehearsal.

Credit to @Oreo-Mcflurry (#130) for the original `set_image_fill` / `createImage` work.
