### PR TITLE
feat: add get_pages and set_current_page, and fix get_document_info's single-page index

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ The MCP server provides the following tools for interacting with Figma:
 
 ### Document & Selection
 
-- `get_document_info` - Get information about the current Figma document
+- `get_document_info` - Get current-page details plus a document-wide page index
+- `get_pages` - Enumerate every page; top-level child counts are opt-in
+- `set_current_page` - Switch the active page for subsequent page-scoped operations
 - `get_selection` - Get information about the current selection
 - `read_my_design` - Get detailed node information about the current selection without parameters
 - `get_node_info` - Get detailed information about a specific node
@@ -231,7 +233,7 @@ The MCP server includes several helper prompts to guide you through complex desi
 When working with the Figma MCP:
 
 1. Always join a channel before sending commands
-2. Get document overview using `get_document_info` first
+2. Get the document page index using `get_pages`, then use `get_document_info` for the current page
 3. Check current selection with `get_selection` before modifications
 4. Use appropriate creation tools based on needs:
    - `create_frame` for containers

--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -128,6 +128,10 @@ async function handleCommand(command, params) {
   switch (command) {
     case "get_document_info":
       return await getDocumentInfo();
+    case "get_pages":
+      return await getPages(params);
+    case "set_current_page":
+      return await setCurrentPage(params);
     case "get_selection":
       return await getSelection();
     case "get_node_info":
@@ -272,7 +276,23 @@ async function handleCommand(command, params) {
 async function getDocumentInfo() {
   await figma.currentPage.loadAsync();
   const page = figma.currentPage;
+  const pages = figma.root.children.map((documentPage) => {
+    const isCurrentPage = documentPage.id === page.id;
+    return {
+      id: documentPage.id,
+      name: documentPage.name,
+      childCount: isCurrentPage ? documentPage.children.length : null,
+      childCountStatus: isCurrentPage ? "available" : "not_requested",
+    };
+  });
+
   return {
+    scope: "current_page_with_document_page_index",
+    document: {
+      id: figma.root.id,
+      name: figma.root.name,
+      type: figma.root.type,
+    },
     name: page.name,
     id: page.id,
     type: page.type,
@@ -286,13 +306,139 @@ async function getDocumentInfo() {
       name: page.name,
       childCount: page.children.length,
     },
-    pages: [
-      {
-        id: page.id,
-        name: page.name,
-        childCount: page.children.length,
-      },
-    ],
+    pageCount: pages.length,
+    pages,
+  };
+}
+
+function startProgressHeartbeat(
+  commandId,
+  commandType,
+  progress,
+  totalItems,
+  processedItems,
+  message
+) {
+  const timer = setInterval(() => {
+    sendProgressUpdate(
+      commandId,
+      commandType,
+      "in_progress",
+      progress,
+      totalItems,
+      processedItems,
+      message
+    ).catch((error) => {
+      console.error(`Failed to send ${commandType} heartbeat:`, error);
+    });
+  }, 15000);
+
+  return () => clearInterval(timer);
+}
+
+async function getPages(params) {
+  const includeChildCount = Boolean(params && params.includeChildCount);
+  const commandId = (params && params.commandId) || generateCommandId();
+  const documentPages = figma.root.children;
+  const pages = [];
+
+  if (includeChildCount) {
+    await sendProgressUpdate(
+      commandId,
+      "get_pages",
+      "started",
+      0,
+      documentPages.length,
+      0,
+      "Loading pages to count top-level children"
+    );
+  }
+
+  for (let index = 0; index < documentPages.length; index++) {
+    const page = documentPages[index];
+    const pageInfo = {
+      id: page.id,
+      name: page.name,
+    };
+
+    if (includeChildCount) {
+      const stopHeartbeat = startProgressHeartbeat(
+        commandId,
+        "get_pages",
+        Math.round((index / documentPages.length) * 100),
+        documentPages.length,
+        index,
+        `Still loading page ${page.name}`
+      );
+      try {
+        await page.loadAsync();
+      } finally {
+        stopHeartbeat();
+      }
+      pageInfo.childCount = page.children.length;
+      await sendProgressUpdate(
+        commandId,
+        "get_pages",
+        "in_progress",
+        Math.round(((index + 1) / documentPages.length) * 100),
+        documentPages.length,
+        index + 1,
+        `Loaded page ${index + 1}/${documentPages.length}: ${page.name}`
+      );
+    }
+
+    pages.push(pageInfo);
+  }
+
+  if (includeChildCount) {
+    await sendProgressUpdate(
+      commandId,
+      "get_pages",
+      "completed",
+      100,
+      documentPages.length,
+      documentPages.length,
+      `Loaded ${documentPages.length} pages`
+    );
+  }
+
+  return {
+    scope: "document",
+    document: {
+      id: figma.root.id,
+      name: figma.root.name,
+    },
+    currentPageId: figma.currentPage.id,
+    pageCount: pages.length,
+    childCountIncluded: includeChildCount,
+    pages,
+  };
+}
+
+async function setCurrentPage(params) {
+  const { pageId } = params || {};
+  if (!pageId) {
+    throw new Error("Missing pageId parameter");
+  }
+
+  const page = await figma.getNodeByIdAsync(pageId);
+  if (!page) {
+    throw new Error(`Page not found with ID: ${pageId}`);
+  }
+  if (page.type !== "PAGE") {
+    throw new Error(`Node ${pageId} is ${page.type}, not a PAGE`);
+  }
+
+  await figma.setCurrentPageAsync(page);
+  await page.loadAsync();
+
+  return {
+    success: true,
+    currentPage: {
+      id: page.id,
+      name: page.name,
+      childCount: page.children.length,
+    },
   };
 }
 

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -89,7 +89,7 @@ const WS_URL = serverUrl === 'localhost' ? `ws://${serverUrl}` : `wss://${server
 // Document Info Tool
 server.tool(
   "get_document_info",
-  "Get detailed information about the current Figma document",
+  "[Current-page scoped, with a document-wide page index] Get top-level details for the current Figma page plus an honest index of every page in the document. Non-current page child counts are explicitly marked as not requested.",
   {},
   async () => {
     try {
@@ -109,6 +109,76 @@ server.tool(
             type: "text",
             text: `Error getting document info: ${error instanceof Error ? error.message : String(error)
               }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Pages Tool
+server.tool(
+  "get_pages",
+  "[Document-wide] Enumerate every page in the Figma document. Top-level child counts are opt-in because dynamic-page access must load each page.",
+  {
+    includeChildCount: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "Load every page and include its top-level child count (default: false)"
+      ),
+  },
+  async ({ includeChildCount }: any) => {
+    try {
+      const result = await sendCommandToFigma("get_pages", {
+        includeChildCount,
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting pages: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+      };
+    }
+  }
+);
+
+// Current Page Tool
+server.tool(
+  "set_current_page",
+  "Switch the active Figma page so subsequent page-scoped reads and writes operate there",
+  {
+    pageId: z.string().describe("The PAGE node ID returned by get_pages"),
+  },
+  async ({ pageId }: any) => {
+    try {
+      const result = await sendCommandToFigma("set_current_page", { pageId });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error setting current page: ${error instanceof Error ? error.message : String(error)}`,
           },
         ],
       };
@@ -2615,6 +2685,8 @@ This detailed process ensures you correctly interpret the reaction data, prepare
 // Define command types and parameters
 type FigmaCommand =
   | "get_document_info"
+  | "get_pages"
+  | "set_current_page"
   | "get_selection"
   | "get_node_info"
   | "get_nodes_info"
@@ -2661,6 +2733,8 @@ type FigmaCommand =
 
 type CommandParams = {
   get_document_info: Record<string, never>;
+  get_pages: { includeChildCount?: boolean };
+  set_current_page: { pageId: string };
   get_selection: Record<string, never>;
   get_node_info: { nodeId: string };
   get_nodes_info: { nodeIds: string[] };


### PR DESCRIPTION
## The bug

`get_document_info` reads `figma.currentPage` and then builds its `pages` array from **that same single page**:

```js
pages: [
  { id: page.id, name: page.name, childCount: page.children.length },
],
```

So the response has the shape of a document summary while describing exactly one page — and it never errors, so a caller has no signal that anything is missing.

Auditing a real multi-page file, this produced a **~100x undercount**: the tool reported 6 frames where the file's mobile page alone holds 764. The number was well-formed, confident, and wrong.

## What this adds

- **`get_pages`** — enumerates `figma.root.children` document-wide. Top-level child counts are **opt-in**, because `documentAccess: "dynamic-page"` requires `loadAsync()` per page and that cost shouldn't be mandatory. The opt-in path emits progress heartbeats so the server's inactivity timeout doesn't fire while pages load.
- **`set_current_page`** — wraps `figma.setCurrentPageAsync`, validating that the target is actually a `PAGE`.
- **`get_document_info`** — now indexes every page, marking each child count `"available"` (current page) or `"not_requested"`. The index can no longer be mistaken for a complete child census.

## Why the pair matters

Together these make an **unattended multi-page sweep** possible for the first time. Previously `set_focus` refused cross-page selection:

> The selection of a page can only include nodes in that page

…so switching page required a human clicking in the Figma UI, which meant any document-wide automation had a manual step in the middle of it.

## Compatibility

Additive. No existing field is removed or changes meaning — `get_document_info` gains `scope`, `document`, and `pageCount`, and its existing `pages` entries gain `childCountStatus`. Callers reading `pages[].id` / `.name` are unaffected; callers that assumed `pages` had length 1 were reading a bug.

## Verification

This repo has no test suite or linter, so this was validated against live Figma files, including the one that produced the undercount above:

- On that file, `get_pages` returns **6 pages** where `get_document_info` previously reported **1**. Top-level child counts: 1 / 826 / **764** / 81 / 1 / 35 — the 764-child page is the one that had been summarised as "6 frames".
- `get_pages({ includeChildCount: true })` completed for **every** page, so the opt-in `loadAsync()` cost is real but tolerable, and the heartbeats keep the inactivity timeout from firing.
- Verified on a second, unrelated 7-page file that `get_document_info` also reported as 1 page.
- `set_current_page` switches pages, and subsequent page-scoped reads operate on the new page.
- `bun run build` succeeds.

Source-only — no `dist/` changes, matching the convention from #185.
